### PR TITLE
fix per-axis conv2d/dense export fail issue

### DIFF
--- a/python/tvm/relay/op/contrib/vsi_npu.py
+++ b/python/tvm/relay/op/contrib/vsi_npu.py
@@ -191,6 +191,9 @@ class QnnQuantizeConstFold(tvm.relay.dataflow_pattern.DFPatternCallback):
         data = pre.args[0].data.numpy()
         scale = pre.args[1].data.numpy()
         zp = pre.args[2].data.numpy()
+        if pre.attrs.axis == 0:  # for perchannel quantize
+            shape = [scale.shape[0]]+[1]*(data.ndim-1)
+            scale = np.reshape(scale, shape)
         data = np.around(data / scale + zp)
         dtype = pre.checked_type.dtype
         if (dtype == "int8"):

--- a/src/relay/backend/contrib/vsi_npu/op_map/field.h
+++ b/src/relay/backend/contrib/vsi_npu/op_map/field.h
@@ -58,9 +58,20 @@ struct Field_Quant_Operand {
       for (uint32_t i = 1; i < scales.size(); i++) {
         zps.push_back(0);
       }
-      quant_spec = tim::vx::Quantization(tim::vx::QuantType::SYMMETRIC_PER_CHANNEL, 0, scales, zps);
+      // for qnn.dense
+      if (shape.size() == 2) {
+        quant_spec = tim::vx::Quantization(tim::vx::QuantType::SYMMETRIC_PER_CHANNEL, 1, scales, zps);
+      } else if (shape.size() == 4) {
+      // for qnn.conv2d
+        quant_spec = tim::vx::Quantization(tim::vx::QuantType::SYMMETRIC_PER_CHANNEL, 3, scales, zps);
+      } else {
+          for (uint32_t i = 0; i < shape.size(); i++) {
+            if (shape[i] == scales.size()) {
+              quant_spec = tim::vx::Quantization(tim::vx::QuantType::SYMMETRIC_PER_CHANNEL, i, scales, zps);
+            }
+          }
+        }
     }
-
     tim::vx::TensorSpec spec(dataType, shape, role, quant_spec);
     return spec;
   }


### PR DESCRIPTION
1. fix per-axis quantized conv2d/dense export issue on vsi_npu

model: pytorch quantized googlenet

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
